### PR TITLE
In the safe_html transform escape attribute values if plone > 2.4

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,9 @@ Changelog
 2.0.8 - unreleased
 ------------------
 
+- In the safe_html transform escape attribute values if python > 2.4.
+  [enfold_josh]
+
 
 2.0.7 - 2011-07-04
 ------------------

--- a/Products/PortalTransforms/transforms/safe_html.py
+++ b/Products/PortalTransforms/transforms/safe_html.py
@@ -13,6 +13,12 @@ from Products.CMFDefault.utils import VALID_TAGS
 from Products.CMFDefault.utils import NASTY_TAGS
 from Products.PortalTransforms.utils import safeToInt
 
+# Escape tag attributes for python > 2.4
+import sys
+ESCAPE_ATTRS = False
+if sys.version_info[0] == 2 and sys.version_info[1] > 4:
+    ESCAPE_ATTRS = True
+
 # tag mapping: tag -> short or long tag
 VALID_TAGS = VALID_TAGS.copy()
 NASTY_TAGS = NASTY_TAGS.copy()
@@ -188,6 +194,8 @@ class StrippingParser(SGMLParser):
                     else:
                         raise IllegalHTML('Script URI "%s" not allowed.' % v)
                 else:
+                    if ESCAPE_ATTRS:
+                        v = escape(v)
                     self.result.append(' %s="%s"' % (k, v))
 
             #UNUSED endTag = '</%s>' % tag


### PR DESCRIPTION
This prevents something like &amp;reg_ in an href from being changed to &reg_ which is interpreted as &reg; by the browser.
