### PR TITLE
fix for transform of entitrefs

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,6 +7,9 @@ Changelog
 - Handle charrefs & entityrefs in data and attributes equaly (unchanged)
   if converting to safe_html
   [tom_gross]
+- In the safe_html transform, make love to entityrefs not to be translited if they are not 'latin-1'.
+  This makes the rest of Archetypes machinery like plone.app.linkintegrity happy.
+  [kiorky]
 
 2.0.7 - 2011-07-04
 ------------------

--- a/Products/PortalTransforms/tests/test_transforms.py
+++ b/Products/PortalTransforms/tests/test_transforms.py
@@ -187,6 +187,24 @@ class SafeHtmlTransformsTest(ATSiteTestCase):
         data = self.pt.convertTo(target_mimetype='text/x-html-safe', orig=orig)
         self.assertEqual(data.getData(), orig)
 
+    def test_unicode_entityref_data(self):
+        orig = '<p><img src="" alt="Fond d&#8217;&eacute;cran 4 saisons (mini)" /></p>'
+        data = self.pt.convertTo(target_mimetype='text/x-html-safe', orig=orig)
+        self.assertEqual(data.getData(), orig)
+
+    def test_unicodetranslited_entityref_data(self):
+        tests = [
+            # in ascii 128 range, can be translited
+            ('<p alt="&amp;"></p>', '<p alt="&"></p>'),
+            # charref can be translited
+            ('<p alt="&delta;"></p>', '<p alt="&#948;"></p>'),
+            # unicode++, not translited
+            # ord('\xa1') 161
+            ('<p alt="&iexcl;"></p>', '<p alt="&iexcl;"></p>'),
+        ]
+        for orig, dest in tests:
+            data = self.pt.convertTo(target_mimetype='text/x-html-safe', orig=orig)
+            self.assertEqual(data.getData(), dest)
 
 TRANSFORMS_TESTINFO = (
     ('Products.PortalTransforms.transforms.pdf_to_html',

--- a/Products/PortalTransforms/transforms/safe_html.py
+++ b/Products/PortalTransforms/transforms/safe_html.py
@@ -161,12 +161,21 @@ class StrippingParser(SGMLParser):
         self.result.append(self.convert_entityref(name))
 
     def convert_entityref(self, name):
-        if name in self.entitydefs:
-            x = ';'
+        """Convert entity references.
+        If the char is not in the ASCII 128 first chars
+        We do not translit the char.
+        """
+        table = self.entitydefs
+        if name in table:
+            # do not convert if there are unicode chars
+            translited = table[name]
+            for char in translited:
+                if ord(char) > 128:
+                    translited = '&%s;' % name
+                    break
+            return translited
         else:
-            # this breaks unstandard entities that end with ';'
-            x = ''
-        return '&%s%s' % (name, x)
+            return
 
     def convert_charref(self, name):
         return '&#%s;' % name

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(name='Products.PortalTransforms',
         test=[
             'zope.testing',
             'Products.Archetypes',
+            'Products.CMFTestCase',
         ],
       ),
       install_requires=[


### PR DESCRIPTION
make love to entityrefs not to be translited if they are not 'latin-1'.
This makes the rest of Archetypes machinery like plone.app.integrity happy.
