### PR TITLE
Add the fenced_code_blocks extension for Markdown Transformations.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,10 +9,15 @@ New:
 - Depend on ``Pillow>=3.1.0``.
   [jensens]
 
+- Add the fenced_code_blocks extension for Markdown Transformations
+  and depend on Markdown >=2.6.5.
+  https://pythonhosted.org/Markdown/extensions/fenced_code_blocks.html
+  [pcdummy]
+
 Fixes:
 
 - Fix: After using ``Pillow>=3.1.0`` fix TIFF test output for this new
-  version of Pillow writing a ``dword`` instead of a ``word`` as type in 
+  version of Pillow writing a ``dword`` instead of a ``word`` as type in
   the IFD header for the width.
   [jensens]
 

--- a/Products/PortalTransforms/transforms/markdown_to_html.py
+++ b/Products/PortalTransforms/transforms/markdown_to_html.py
@@ -36,7 +36,7 @@ class markdown(object):
             # PortalTransforms, however expects a string as result,
             # so we encode the unicode result back to UTF8:
             html = markdown_transformer \
-                .markdown(orig, extensions=['fenced_code']) \
+                .markdown(orig, extensions=['markdown.extensions.fenced_code']) \
                 .encode('utf-8')
         else:
             html = orig

--- a/Products/PortalTransforms/transforms/markdown_to_html.py
+++ b/Products/PortalTransforms/transforms/markdown_to_html.py
@@ -35,7 +35,9 @@ class markdown(object):
             orig = unicode(orig.decode('utf-8'))
             # PortalTransforms, however expects a string as result,
             # so we encode the unicode result back to UTF8:
-            html = markdown_transformer.markdown(orig).encode('utf-8')
+            html = markdown_transformer \
+                .markdown(orig, extensions=['fenced_code']) \
+                .encode('utf-8')
         else:
             html = orig
         data.setData(html)

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,6 @@ setup(name='Products.PortalTransforms',
           'Acquisition',
           'ZODB3',
           'Zope2',
-          'Markdown>=1.7',
+          'Markdown>=2.6.5',
       ],
 )


### PR DESCRIPTION
Add the [fenced_code_blocks](https://pythonhosted.org/Markdown/extensions/fenced_code_blocks.html) extension for Markdown Transformations.
and depend on Markdown >=2.6.5.

It allows Github like 

    >>> orig = u'```bash\nbash_code\n```'
    >>> import markdown; print markdown.markdown(orig, extensions=['fenced_code'])

    <<< <pre><code style="bash">bash_code</code/<pre>

Output.

The Markdown version we ship currently doesn't work with fenced_code_blocks, where can i change the "[versions]" entry?
  