### PR TITLE
Fix rest heading level regression introduced in 2.2.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,12 @@ New:
 
 Fixes:
 
+- Fix regression in rest transform vs. old Zope2 reStructuredText wrapper:
+  headings now proper level in settings for body, which was necessary to
+  preserve levels assumed in downstream use of this transform
+  (e.g. Archetypes).  Behavior now matches that of previous wrapper.
+  [seanupton]
+
 - *add item here*
 
 

--- a/Products/PortalTransforms/transforms/rest.py
+++ b/Products/PortalTransforms/transforms/rest.py
@@ -100,7 +100,7 @@ class rest(object):
             'raw_enabled': 0,
             'language_code': language,
             # starting level for <H> elements:
-            'initial_header_level': initial_header_level,
+            'initial_header_level': initial_header_level + 1,
             # set the reporting level to something sane:
             'report_level': report_level,
             # don't break if we get errors:


### PR DESCRIPTION
Levels in body headings now match what was previously output by old Zope2
reStructuredText wrapper, which means Products.Archetypes tests for
transforms will pass again.

Prior to this coredev buildout (5.1) test for Products.Archetypes fails on tranform/BaseUnit tests with Products.PortalTransforms 2.2.0.  This should alleviate that.

Attn: @pbauer -- can you review this?