### PR TITLE
Improper warnings on broken transform

### DIFF
--- a/Products/PortalTransforms/transforms/broken.py
+++ b/Products/PortalTransforms/transforms/broken.py
@@ -1,10 +1,8 @@
 # -*- coding: utf-8 -*-
+import logging
 from Products.PortalTransforms.interfaces import ITransform
 from Products.PortalTransforms.utils import log
 from zope.interface import implementer
-
-
-WARNING = 100
 
 
 @implementer(ITransform)
@@ -26,8 +24,7 @@ class BrokenTransform(object):
         # do the format
         msg = "Calling convert on BROKEN transform %s (%s). Error: %s" % \
               (self.id, self.module, self.error)
-        log(msg, severity=WARNING)
-        print msg
+        log(msg, severity=logging.WARNING)
         data.setData('')
         return data
 


### PR DESCRIPTION
The broken.py module is particularly noisy. For reasons, I wanted to ignore some warnings from this module but encountered two issues when trying to set the threshold for the PortalTransforms logger above WARN.

1. It doesn't just log the error, it also prints to the console
2. The severity of the log message does not use logging.WARNING (30) it uses a global variable named WARNING that is set to 100. That is well above the level for CRITICAL (50)!!!

This pull request removes the print message and sets the severity to logging.WARNING.