### PR TITLE
fixes Old safe_html config still visible after upgrade to Plone 5.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,9 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Do not expose dead settings in ``safe_html`` ZMI settings page.
+  This fixes `Products.CMFPlone #2130 <https://github.com/plone/Products.CMFPlone/issues/2130>`_
+  [jensens]
 
 
 3.1 (2017-09-03)

--- a/Products/PortalTransforms/www/configureTransform.zpt
+++ b/Products/PortalTransforms/www/configureTransform.zpt
@@ -1,9 +1,19 @@
 <h1 tal:replace="structure here/manage_page_header|nothing">Header</h1>
 <h2 tal:define="manage_tabs_message options/manage_tabs_message | nothing"
     tal:replace="structure here/manage_tabs">Tabs</h2>
+<tal:set tal:define="is_safe_html python:context.getId() == 'safe_html'">
+  <div tal:condition="is_safe_html">
+    <p>
+      Since Plone 5.1 all <em>safe_html</em> transform related parameters are no longer set through the Management Interface.
+    </p>
 
+    <p>
+      The new settings are found now in the Plone <a href="${context/portal_url}/@@filter-controlpanel">Filter Control Panel</a>
+    </p>
+  </div>
 
   <form method="POST"
+        tal:condition="not: is_safe_html"
         tal:attributes="action string:${here/absolute_url}/set_parameters"
         tal:define="params here/get_parameters">
 
@@ -47,6 +57,6 @@
     </p>
 
   </form>
-
+</tal:set>
 <tal:footer tal:replace="structure here/manage_page_footer|nothing">footer</tal:footer>
 


### PR DESCRIPTION
fixes plone/Products.CMFPlone#2130