### PR TITLE
Begin fixing startup in py3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,9 @@ Bug fixes:
 
 Bug fixes:
 
+- Start fixing startup in py3
+  [pbauer]
+
 - Add Python 2 / 3 compatibility.  [maurits]
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,16 +14,14 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Start fixing startup in py3
+  [pbauer]
 
 
 3.1.2 (2018-02-05)
 ------------------
 
 Bug fixes:
-
-- Start fixing startup in py3
-  [pbauer]
 
 - Add Python 2 / 3 compatibility.  [maurits]
 

--- a/Products/PortalTransforms/Transform.py
+++ b/Products/PortalTransforms/Transform.py
@@ -13,11 +13,13 @@ from Products.PortalTransforms.transforms.broken import BrokenTransform
 from Products.PortalTransforms.utils import _www
 from Products.PortalTransforms.utils import log
 from Products.PortalTransforms.utils import TransformException
-from UserDict import UserDict
+from six.moves import reload_module
 from zope.interface import implementer
 
-
-from six.moves import reload_module
+try:
+    from collections import UserDict
+except ImportError:
+    from UserDict import UserDict
 
 
 def import_from_name(module_name):
@@ -56,6 +58,7 @@ def make_config_nonpersistent(kwargs):
         elif isinstance(value, PersistentList):
             p_value = list(value)
             kwargs[key] = p_value
+
 
 VALIDATORS = {
     'int': int,

--- a/Products/PortalTransforms/chain.py
+++ b/Products/PortalTransforms/chain.py
@@ -11,11 +11,12 @@ from Products.PageTemplates.PageTemplateFile import PageTemplateFile
 from Products.PortalTransforms.interfaces import IChain
 from Products.PortalTransforms.interfaces import ITransform
 from Products.PortalTransforms.utils import _www
-from UserList import UserList
 from zope.interface import implementer
 
-
-from six.moves import reload_module
+try:
+    from collections import UserList
+except ImportError:
+    from UserList import UserList
 
 
 @implementer(IChain, ITransform)

--- a/Products/PortalTransforms/data.py
+++ b/Products/PortalTransforms/data.py
@@ -7,11 +7,11 @@ class datastream(object):
     """A transformation datastream packet"""
 
     __slots__ = (
-        'name', '_data', '_metadata', '__name__', '_objects', '_cacheable'
+        'name_', '_data', '_metadata', '__name__', '_objects', '_cacheable'
     )
 
-    def __init__(self, name):
-        self.__name__ = name
+    def __init__(self, name_):
+        self.__name__ = name_
         self._data = ''
         self._metadata = {}
         self._objects = {}


### PR DESCRIPTION
There is the following issue during startup in python3 only:

```
from Products.PortalTransforms.data import datastream
  File "/Users/pbauer/workspace/coredev_py3/src/Products.PortalTransforms/Products/PortalTransforms/data.py", line 6, in <module>
    class datastream(object):
ValueError: 'name' in __slots__ conflicts with class variable
```

That results from:

```python
@implementer(IDataStream)
class datastream(object):
    """A transformation datastream packet"""

    __slots__ = (
        'name', '_data', '_metadata', '__name__', '_objects', '_cacheable'
    )

    def __init__(self, name):
        self.__name__ = name
        self._data = ''
        self._metadata = {}
        self._objects = {}
        self._cacheable = 1
```

Would it be safe to rename `name` to `name_` or could that be used anywhere except for assigning `self.__name__`?