### PR TITLE
Fix transform output type

### DIFF
--- a/Products/PortalTransforms/TransformEngine.py
+++ b/Products/PortalTransforms/TransformEngine.py
@@ -84,7 +84,7 @@ class TransformTool(UniqueObject, ActionProviderBase, Folder):
                   usedby=None, context=None, **kwargs):
         """Convert orig to a given mimetype
 
-        * orig is an encoded string
+        * orig is a native string
 
         * data an optional IDataStream object. If None a new datastream will be
         created and returned

--- a/Products/PortalTransforms/data.py
+++ b/Products/PortalTransforms/data.py
@@ -24,11 +24,13 @@ class datastream(object):
         return self.__name__
 
     def setData(self, value):
-        """set the main data produced by a transform, i.e. usually a string"""
+        """set the main data produced by a transform,
+        i.e. usually a native string"""
         self._data = value
 
     def getData(self):
-        """provide access to the transformed data object, i.e. usually a string
+        """provide access to the transformed data object,
+        i.e. usually a native string
         This data may references subobjects.
         """
         if callable(self._data):

--- a/Products/PortalTransforms/interfaces.py
+++ b/Products/PortalTransforms/interfaces.py
@@ -9,10 +9,12 @@ class IDataStream(Interface):
     """data stream, is the result of a transform"""
 
     def setData(value):
-        """set the main data produced by a transform, i.e. usually a string"""
+        """set the main data produced by a transform,
+        i.e. usually a native string"""
 
     def getData():
-        """provide access to the transformed data object, i.e. usually a string
+        """provide access to the transformed data object,
+        i.e. usually a native string
         This data may references subobjects.
         """
 
@@ -87,7 +89,7 @@ class IEngine(Interface):
                   **kwargs):
         """Convert orig to a given mimetype
 
-        * orig is an encoded string
+        * orig is a native string
 
         * data an optional idatastream object. If None a new datastream will be
         created and returned
@@ -120,6 +122,7 @@ class IEngine(Interface):
         return an encoded string.
         see convert docstring for more info on additional arguments.
         """
+
 
 # BBB
 idatastream = IDataStream

--- a/Products/PortalTransforms/libtransforms/retransform.py
+++ b/Products/PortalTransforms/libtransforms/retransform.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from Products.CMFPlone.utils import safe_unicode
+from Products.PortalTransforms.utils import safe_nativestring
 from Products.PortalTransforms.interfaces import ITransform
 from zope.interface import implementer
 
@@ -26,7 +26,7 @@ class retransform:
         self.regexes.append((r, repl))
 
     def convert(self, orig, data, **kwargs):
-        orig = safe_unicode(orig)
+        orig = safe_nativestring(orig)
         for r, repl in self.regexes:
             orig = r.sub(repl, orig)
         data.setData(orig)

--- a/Products/PortalTransforms/libtransforms/utils.py
+++ b/Products/PortalTransforms/libtransforms/utils.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-from Products.CMFPlone.utils import safe_unicode
 from Products.PortalTransforms.utils import log
+from Products.PortalTransforms.utils import safe_nativestring
 
 import os
 import sys
@@ -79,7 +79,7 @@ def bodyfinder(text):
     Always use html_headcheck() first.
     Accepts bytes or text. Returns text.
     """
-    text = safe_unicode(text)
+    text = safe_nativestring(text)
     lowertext = text.lower()
     bodystart = lowertext.find('<body')
     if bodystart == -1:

--- a/Products/PortalTransforms/setuphandlers.py
+++ b/Products/PortalTransforms/setuphandlers.py
@@ -3,8 +3,7 @@ PortalTransforms setup handlers.
 """
 from __future__ import print_function
 from Products.CMFCore.utils import getToolByName
-
-from six import StringIO
+from six import StringIO as NativeStringIO
 
 
 def correctMapping(out, portal):
@@ -53,7 +52,7 @@ def updateTransform(out, portal, transform_id):
 
 
 def installPortalTransforms(portal):
-    out = StringIO()
+    out = NativeStringIO()
 
     updateTransform(out, portal, 'safe_html')
     updateTransform(out, portal, 'markdown_to_html')

--- a/Products/PortalTransforms/tests/base.py
+++ b/Products/PortalTransforms/tests/base.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import unittest
 
-from Products.CMFPlone.utils import safe_unicode
 from Products.PortalTransforms.testing import PRODUCTS_PORTALTRANSFORMS_INTEGRATION_TESTING  # noqa
 
 
@@ -9,14 +8,8 @@ class TransformTestCase(unittest.TestCase):
 
     layer = PRODUCTS_PORTALTRANSFORMS_INTEGRATION_TESTING
 
+    allowed_types = str
+
     def setUp(self):
         self.portal = self.layer['portal']
         self.transforms = self.portal.portal_transforms
-
-    def _baseAssertEqual(self, first, second, msg=None):
-        return unittest.TestCase._baseAssertEqual(
-            self, safe_unicode(first), safe_unicode(second), msg)
-
-    def assertMultiLineEqual(self, first, second, msg=None):
-        return unittest.TestCase.assertMultiLineEqual(
-            self, safe_unicode(first), safe_unicode(second), msg)

--- a/Products/PortalTransforms/tests/utils.py
+++ b/Products/PortalTransforms/tests/utils.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-from Products.CMFPlone.utils import safe_unicode
 from Products.PortalTransforms.transforms.safe_html import html5entities
+from Products.PortalTransforms.utils import safe_nativestring
 from os.path import abspath
 from os.path import basename
 from os.path import dirname
@@ -14,8 +14,7 @@ import six
 
 
 def normalize_html(s):
-    if six.PY3 and isinstance(s, six.binary_type):
-        s = safe_unicode(s)
+    s = safe_nativestring(s)
     s = re.sub(r"&nbsp;", " ", s)
     s = re.sub(r"&#160;", " ", s)
     s = re.sub(r"\s+", " ", s)

--- a/Products/PortalTransforms/transforms/markdown_to_html.py
+++ b/Products/PortalTransforms/transforms/markdown_to_html.py
@@ -5,12 +5,11 @@ Uses the http://www.freewisdom.org/projects/python-markdown/ module
 Author: Tom Lazar <tom@tomster.org> at the archipelago sprint 2006
 """
 
+from Products.CMFPlone.utils import safe_unicode
 from Products.PortalTransforms.interfaces import ITransform
 from Products.PortalTransforms.utils import log
+from Products.PortalTransforms.utils import safe_nativestring
 from zope.interface import implementer
-
-
-import six
 
 
 try:
@@ -58,15 +57,14 @@ class markdown(object):
     def convert(self, orig, data, **kwargs):
         if HAS_MARKDOWN:
             # markdown expects unicode input:
-            orig = six.text_type(orig.decode('utf-8'))
-            # PortalTransforms, however expects a string as result,
-            # so we encode the unicode result back to UTF8:
-            html = markdown_transformer \
-                .markdown(orig, extensions=self.config.get('enabled_extensions', [])) \
-                .encode('utf-8')
+            html = markdown_transformer.markdown(
+                safe_unicode(orig),
+                extensions=self.config.get('enabled_extensions', [])
+            )
         else:
             html = orig
-        data.setData(html)
+
+        data.setData(safe_nativestring(html))
         return data
 
 

--- a/Products/PortalTransforms/transforms/python.py
+++ b/Products/PortalTransforms/transforms/python.py
@@ -16,8 +16,9 @@ Original code from active state recipe
 """
 
 from DocumentTemplate.DT_Util import html_quote
+from io import BytesIO
 from Products.PortalTransforms.interfaces import ITransform
-from six import BytesIO
+from Products.PortalTransforms.utils import safe_nativestring
 from zope.interface import implementer
 
 import keyword
@@ -71,7 +72,7 @@ class Parser(object):
             self.out.write(b"<h5 class='error>'ERROR: %s%s</h5>" % (
                 msg, self.raw[self.lines[line]:]))
         self.out.write(b'\n</pre>\n')
-        return self.out.getvalue()
+        return safe_nativestring(self.out.getvalue())
 
     def format_tokenizer(self, toktype, toktext, sx, ex, line):
         """ Token handler.

--- a/Products/PortalTransforms/transforms/text_to_html.py
+++ b/Products/PortalTransforms/transforms/text_to_html.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
-import six
-
 from DocumentTemplate.DT_Util import html_quote
-from Products.CMFPlone.utils import safe_unicode
 from Products.PortalTransforms.interfaces import ITransform
+from Products.PortalTransforms.utils import safe_nativestring
 from zope.interface import implementer
 
 
@@ -36,9 +34,7 @@ class TextToHTML(object):
         raise AttributeError(attr)
 
     def convert(self, orig, data, **kwargs):
-        orig = safe_unicode(orig)
-        if six.PY2:
-            orig = orig.encode(kwargs.get('encoding', 'utf-8'))
+        orig = safe_nativestring(orig)
         # Replaces all line breaks with a br tag, and wraps it in a p tag.
         data.setData('<p>%s</p>' %
                      html_quote(orig.strip()).replace('\n', '<br />'))

--- a/Products/PortalTransforms/unsafe_transforms/xml.py
+++ b/Products/PortalTransforms/unsafe_transforms/xml.py
@@ -17,7 +17,7 @@ from zope.interface import implementer
 import re
 
 
-from six.moves import cStringIO as StringIO
+from six import StringIO as NativeStringIO
 
 
 @implementer(ITransform)
@@ -154,7 +154,7 @@ def get_doctype(data):
     """ return the public id for the doctype given some raw xml data
     """
     if not hasattr(data, 'readlines'):
-        data = StringIO(data)
+        data = NativeStringIO(data)
     for line in data.readlines():
         line = line.strip()
         if not line:
@@ -172,7 +172,7 @@ def get_dtd(data):
     """ return the public id for the doctype given some raw xml data
     """
     if not hasattr(data, 'readlines'):
-        data = StringIO(data)
+        data = NativeStringIO(data)
     for line in data.readlines():
         line = line.strip()
         if not line:

--- a/Products/PortalTransforms/utils.py
+++ b/Products/PortalTransforms/utils.py
@@ -3,10 +3,28 @@
 # directory where template for the ZMI are located
 import logging
 import os.path
+import six
+
+try:
+    from Products.CMFPlone.utils import safe_nativestring
+except ImportError:
+    # Not needed for Products.CMFPlone >= 5.2a1
+    from Products.CMFPlone.utils import safe_encode
+    from Products.CMFPlone.utils import safe_unicode
+
+    def safe_nativestring(value, encoding='utf-8'):
+        """Convert a value to str in py2 and to text in py3
+        """
+        if six.PY2 and isinstance(value, six.text_type):
+            value = safe_encode(value, encoding)
+        if not six.PY2 and isinstance(value, six.binary_type):
+            value = safe_unicode(value, encoding)
+        return value
 
 
 class TransformException(Exception):
     pass
+
 
 FB_REGISTRY = None
 
@@ -16,6 +34,7 @@ logger = logging.getLogger('PortalTransforms')
 
 def log(message, severity=logging.DEBUG):
     logger.log(severity, message)
+
 
 _www = os.path.join(os.path.dirname(__file__), 'www')
 

--- a/news/37.bugfix
+++ b/news/37.bugfix
@@ -1,0 +1,1 @@
+Some transform were returning unicode instead of strings in Python 2


### PR DESCRIPTION
It should be usually a native string, except when we deal with
transforms that return images and files

Fixes #37