### PR TITLE
When form tag is added to the valid tags, do not remove it anyway.

### DIFF
--- a/Products/PortalTransforms/transforms/safe_html.py
+++ b/Products/PortalTransforms/transforms/safe_html.py
@@ -2444,6 +2444,7 @@ class SafeHTML:
                           meta=False,
                           javascript=remove_script,
                           scripts=remove_script,
+                          forms=False,
                           style=False)
         try:
             cleaner(tree)

--- a/news/2693.bugfix
+++ b/news/2693.bugfix
@@ -1,0 +1,4 @@
+When form tag is added to the valid tags, do not remove it anyway.
+By default the cleaner would always remove form tags and kill button, input, select, and textarea tags
+Fixes `issue 2693 <https://github.com/plone/Products.CMFPlone/issues/2693>`_.
+[maurits]


### PR DESCRIPTION
By default the cleaner would always remove form tags and kill button, input, select, and textarea tags
Fixes https://github.com/plone/Products.CMFPlone/issues/2693.
See [my explanation](https://github.com/plone/Products.CMFPlone/issues/2693#issuecomment-465765113) in that issue.