### PR TITLE
Fixed deprecation warning for DocumentTemplate.DT_Util.html_quote.

### DIFF
--- a/Products/PortalTransforms/transforms/python.py
+++ b/Products/PortalTransforms/transforms/python.py
@@ -15,7 +15,7 @@ Original code from active state recipe
  original formatting (which is the hard part).
 """
 
-from DocumentTemplate.DT_Util import html_quote
+from DocumentTemplate.html_quote import html_quote
 from io import BytesIO
 from Products.PortalTransforms.interfaces import ITransform
 from Products.PortalTransforms.utils import safe_nativestring

--- a/Products/PortalTransforms/transforms/text_pre_to_html.py
+++ b/Products/PortalTransforms/transforms/text_pre_to_html.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from DocumentTemplate.DT_Util import html_quote
+from DocumentTemplate.html_quote import html_quote
 from Products.PortalTransforms.interfaces import ITransform
 from zope.interface import implementer
 

--- a/Products/PortalTransforms/transforms/text_to_html.py
+++ b/Products/PortalTransforms/transforms/text_to_html.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from DocumentTemplate.DT_Util import html_quote
+from DocumentTemplate.html_quote import html_quote
 from Products.PortalTransforms.interfaces import ITransform
 from Products.PortalTransforms.utils import safe_nativestring
 from zope.interface import implementer

--- a/news/41.bugfix
+++ b/news/41.bugfix
@@ -1,0 +1,2 @@
+Fixed deprecation warning for DocumentTemplate.DT_Util.html_quote.
+[maurits]


### PR DESCRIPTION
```
DeprecationWarning: html_quote is deprecated. Please import from DocumentTemplate.html_quote. These shims will go away in DocumentTemplate 4.0.
```

This is already available under DocumentTemplate.html_quote.html_quote since at least 2.13.6, so safe to change.