### PR TITLE
Split method cleaner_options off from scrub_html in safe_html transform.

### DIFF
--- a/news/44.bugfix
+++ b/news/44.bugfix
@@ -1,0 +1,3 @@
+Split method cleaner_options off from scrub_html in safe_html transform.
+This makes it easier to monkey patch or subclass.
+[maurits]


### PR DESCRIPTION
This makes it easier to monkey patch or subclass.

My use case for an override is to allow `script` tags from one specific domain and not any other.
Sample monkey patch:

```
from Products.PortalTransforms.transforms.safe_html import SafeHTML

HOST_WHITELIST = (
    "mautic.example.com",
)

def updated_cleaner_options(self):
    # Get standard options from Plone:
    opts = self._orig_cleaner_options()
    # Have a domain whitelist:
    opts["host_whitelist"] = HOST_WHITELIST
    # Specify the tags for which the host_whitelist is checked on a few known attributes (src),
    # default is iframe and embed:
    opts["whitelist_tags"] = {'iframe', 'embed', 'script'}
    # Allow the script tag, to prevent it being removed, with only the contents kept
    if "script" not in opts["allow_tags"]:
        opts["allow_tags"].append("script")
    # Remove 'on:' attributes:
    opts["javascript"] = 1
    # Let the cleaner add script to the kill_tags/nasty_tags:
    opts["scripts"] = 1
    return opts

SafeHTML._orig_cleaner_options = SafeHTML.cleaner_options
SafeHTML.cleaner_options = updated_cleaner_options
```
