### PR TITLE
REST transform: ignore warnings and stylesheet keyword arguments.

### DIFF
--- a/Products/PortalTransforms/tests/test_transforms.py
+++ b/Products/PortalTransforms/tests/test_transforms.py
@@ -33,6 +33,7 @@ import hashlib
 import itertools
 import os
 import six
+import unittest
 
 
 # we have to set locale because lynx output is locale sensitive !
@@ -457,6 +458,48 @@ class ParsersTestCase(TransformTestCase):
         self.assertEqual(SafeHTML().scrub_html(data).strip(), '')
 
 
+class RestTransformsTest(unittest.TestCase):
+
+    def test_rest_convert(self):
+        # from PloneHotfix20210518
+        from Products.PortalTransforms.data import datastream
+        from Products.PortalTransforms.transforms.rest import rest
+
+        # Try to convert ReStructuredText resulting in a warning.
+        orig = "Hello *world"
+        data = datastream("foo")
+        transform = rest()
+        # With the warnings parameter you could write to the filesystem.
+        # With the stylesheet parameter you could read from the filesystem.
+        # https://sourceforge.net/p/docutils/bugs/413/
+        here = os.path.dirname(__file__)
+        warnings_file = os.path.join(here, "write.txt")
+        css_file = os.path.join(here, "read.css")
+        read_contents = "Arbitrary file read from OS."
+        with open(css_file, "w") as css:
+            css.write(read_contents)
+        bad_keyword_arguments = {
+            "warnings": warnings_file,
+            "stylesheet": css_file,
+        }
+        try:
+            result = transform.convert(orig, data, **bad_keyword_arguments)
+            output = result.getData()
+            # There should be a warning for the wrong ReStructuredText.
+            self.assertIn("WARNING", output)
+            # The contents of the css file should not be in the result.
+            self.assertNotIn(read_contents, output)
+            self.assertNotIn(css_file, output)
+            # No file should have been written to the system.
+            self.assertFalse(os.path.exists(warnings_file))
+        finally:
+            # cleanup
+            if os.path.exists(warnings_file):
+                os.remove(warnings_file)
+            if os.path.exists(css_file):
+                os.remove(css_file)
+
+
 TRANSFORMS_TESTINFO = (
     ('Products.PortalTransforms.transforms.pdf_to_html',
      "demo1.pdf", "demo1.html", normalize_html, 0, str,
@@ -582,6 +625,7 @@ def make_tests(test_descr=TRANSFORMS_TESTINFO):
     tests.append(SafeHtmlTransformsWithFormTest)
     tests.append(WordTransformsTest)
     tests.append(ParsersTestCase)
+    tests.append(RestTransformsTest)
     return tests
 
 

--- a/Products/PortalTransforms/transforms/rest.py
+++ b/Products/PortalTransforms/transforms/rest.py
@@ -3,7 +3,6 @@ from Products.PortalTransforms.interfaces import ITransform
 from docutils.core import publish_parts
 from zope.interface import implementer
 
-
 import six
 
 
@@ -88,16 +87,20 @@ class rest(object):
         input_encoding = kwargs.get('input_encoding', encoding)
         output_encoding = kwargs.get('output_encoding', encoding)
         language = kwargs.get('language', 'en')
-        warnings = kwargs.get('warnings', None)
-        stylesheet = kwargs.get('stylesheet', None)
         initial_header_level = int(self.config.get('initial_header_level', 2))
         report_level = int(self.config.get('report_level', 2))
+        # Note: we must NOT use warning_stream and stylesheet, because an attacker can abuse them.
+        # See https://sourceforge.net/p/docutils/bugs/413/
+        # Part of PloneHotfix20210518.
+        # It would be okay if we can be sure this method is called from trusted Python code,
+        # but we cannot be sure.
+        # We keep them in the settings, to be sure nothing changes due to this fix.
         settings = {
             'documentclass': '',
             'traceback': 1,
             'input_encoding': input_encoding,
             'output_encoding': output_encoding,
-            'stylesheet': stylesheet,
+            'stylesheet': None,
             'stylesheet_path': None,
             'file_insertion_enabled': 0,
             'raw_enabled': 0,
@@ -109,7 +112,7 @@ class rest(object):
             # don't break if we get errors:
             'halt_level': 6,
             # remember warnings:
-            'warning_stream': warnings,
+            'warning_stream': None
         }
 
         parts = publish_parts(

--- a/news/3274.bugfix
+++ b/news/3274.bugfix
@@ -1,0 +1,4 @@
+REST transform: ignore warnings and stylesheet keyword arguments.
+They can be abused.
+From `Products.PloneHotfix20210518 <https://plone.org/security/hotfix/20210518/writing-arbitrary-files-via-docutils-and-python-script>`_.
+[maurits]


### PR DESCRIPTION
They can be abused.
From [Products.PloneHotfix20210518](https://plone.org/security/hotfix/20210518/writing-arbitrary-files-via-docutils-and-python-script).