### PR TITLE
Tests: fixed incompatibility with lxml 3.9+ on Linux.

### DIFF
--- a/news/818.bugfix
+++ b/news/818.bugfix
@@ -1,0 +1,3 @@
+Tests: fixed incompatibility with lxml 3.9+ on Linux.
+This gives slightly different output.
+[maurits]


### PR DESCRIPTION
This gives slightly different output.
I feared this indicated a cross site scripting problem, but this is not the case. See https://github.com/plone/buildout.coredev/pull/818