### PR TITLE
Fixed regular expression in tests on Python 3.11.

### DIFF
--- a/Products/PortalTransforms/tests/test_engine.py
+++ b/Products/PortalTransforms/tests/test_engine.py
@@ -22,8 +22,8 @@ class HtmlToText(BaseTransform):
     output = 'text/plain'
 
     def __call__(self, orig, **kwargs):
-        orig = re.sub('<[^>]*>(?i)(?m)', '', orig)
-        return urllib.parse.unquote(re.sub('\n+', '\n', orig)).strip()
+        orig = re.sub(r'(?i)(?m)<[^>]*>', '', orig)
+        return urllib.parse.unquote(re.sub(r'\n+', '\n', orig)).strip()
 
     def convert(self, orig, data, **kwargs):
         orig = self.__call__(orig)
@@ -42,7 +42,7 @@ class FooToBar(BaseTransform):
 
     def __call__(self, orig, **kwargs):
         orig = re.sub('foo', 'bar', orig)
-        return urllib.parse.unquote(re.sub('\n+', '\n', orig)).strip()
+        return urllib.parse.unquote(re.sub(r'\n+', '\n', orig)).strip()
 
     def convert(self, orig, data, **kwargs):
         orig = self.__call__(orig)

--- a/news/48.bugfix
+++ b/news/48.bugfix
@@ -1,0 +1,2 @@
+Fixed regular expression in tests on Python 3.11.
+[maurits]


### PR DESCRIPTION
This fixes https://github.com/plone/Products.PortalTransforms/issues/48