### PR TITLE
Use Cleaner from new package lxml_html_clean.

### DIFF
--- a/Products/PortalTransforms/tests/test_xss.py
+++ b/Products/PortalTransforms/tests/test_xss.py
@@ -251,7 +251,12 @@ class TestXSSFilter(unittest.TestCase):
             """<p><a href="http://T\\foo\\20111015\\bar.msg">FOO</a></p>"""  # noqa
         )
         data_out = """<p><a href="http://T%5Cfoo%5C20111015%5Cbar.msg">FOO</a></p>"""
-        self.doTest(data_in, data_out)
+        # When we were still using lxml.xml, converting data_in gave data_in as anwer.
+        # Then we switched to lxml.html, which caused the backslashes to be converted
+        # into '%5C'.  And now when we upgrade from lxml 4 to 5, data_in is again
+        # unchanged after converting.  So let's accept both.
+        result = self.doConvert(data_in)
+        self.assertIn(result, (data_in, data_out))
 
     def test_39(self):
         data_in = """<a href="&#42;&Ascr;\xa9"></a>"""

--- a/Products/PortalTransforms/transforms/safe_html.py
+++ b/Products/PortalTransforms/transforms/safe_html.py
@@ -1,7 +1,7 @@
 from html.entities import html5 as html5entities
 from lxml import etree
 from lxml import html
-from lxml.html.clean import Cleaner
+from lxml_html_clean import Cleaner
 from plone.base.interfaces import IFilterSchema
 from plone.base.utils import safe_bytes
 from plone.registry.interfaces import IRegistry

--- a/news/3938.bugfix
+++ b/news/3938.bugfix
@@ -1,0 +1,4 @@
+Use ``Cleaner`` from new package ``lxml_html_clean``.
+This was factored out from ``lxml`` in version 5.2.0.
+See https://lxml-html-clean.readthedocs.io/
+[maurits]

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(
         "Products.GenericSetup",
         "setuptools",
         "lxml",
+        "lxml_html_clean",
         "persistent",
         "plone.base",
         "plone.registry",


### PR DESCRIPTION
This was factored out from ``lxml`` in version 5.2.0. See https://lxml-html-clean.readthedocs.io/

Fixes https://github.com/plone/Products.CMFPlone/issues/3938

Alternatively we could depend on `lxml[html_clean]`, but I think it is cleaner (pun intended) to directly depend on the new package. Also, this means it is still possible to use an older `lxml` version that does not have the `html_clean` extra, if needed.